### PR TITLE
Fix help typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The following command line options are allowed:
 
 - `-h` Display help
 
-- `-a <adapter>` Set the adpter
+- `-a <adapter>` Set the adapter
 
 - `-d <rate>` Set maximum download rate (in Kbps) and/or
 

--- a/wondershaper
+++ b/wondershaper
@@ -25,7 +25,7 @@ Limit the bandwidth of an adapter
 
 OPTIONS:
    -h           Show this message
-   -a <adapter> Set the adpter
+   -a <adapter> Set the adapter
    -d <rate>    Set maximum download rate (in Kbps) and/or
    -u <rate>    Set maximum upload rate (in Kbps)
    -p           Use presets in /etc/conf.d/wondershaper.conf


### PR DESCRIPTION
This fixes a misspelling of adapter in the README and help message.