### PR TITLE
Return codes for systemctl support

### DIFF
--- a/wondershaper
+++ b/wondershaper
@@ -112,7 +112,7 @@ fi;
 if [ "$MODE" = "status" ]; then
     tc -s qdisc ls dev "$IFACE";
     tc -s class ls dev "$IFACE";
-    exit;
+    exit 0;
 fi;
 
 if [ "$MODE" = "clear" ]; then
@@ -120,7 +120,7 @@ if [ "$MODE" = "clear" ]; then
     tc qdisc del dev "$IFACE" ingress 2> /dev/null > /dev/null;
     tc qdisc del dev "$IFB"   root    2> /dev/null > /dev/null;
     tc qdisc del dev "$IFB"   ingress 2> /dev/null > /dev/null;
-    exit;
+    exit 0;
 fi;
 
 if { [[ -z "$DSPEED" ]] && [[ -z "$USPEED" ]]; } || [[ -z "$IFACE" ]]; then


### PR DESCRIPTION
This commit fixes the issue that appears when wondershaper is running under systemctl. wondershaper -c -a <IFACE> would cause systemctl to treat the service as failed due to missing exit code 0.

 wondershaper.service - Bandwidth shaper/Network rate limiter
   Loaded: loaded (/usr/lib/systemd/system/wondershaper.service; disabled; vendor preset: enabled)
   Active: failed (Result: exit-code) since di 2020-12-01 11:57:44 CET; 1min 30s ago
  Process: 13281 ExecStop=/usr/bin/wondershaper -c -a $IFACE (code=exited, status=2)
