### PR TITLE
Systemd dependency fix

### DIFF
--- a/wondershaper.service
+++ b/wondershaper.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Bandwidth shaper/Network rate limiter
-After=network.target
+After=network-online.target
 Wants=network.target
 
 [Service]


### PR DESCRIPTION
The dependency from **network.target** on some system fails due to the fact that the network subsystem maybe not yet initialized, instead it should depend from **network-online.target**.