### PR TITLE
Makefile: Use standard GNU prefixes

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,15 +1,24 @@
+# Common prefixes for installation directories.
+# See: https://www.gnu.org/software/make/manual/make.html
+prefix = /usr/local
+exec_prefix = $(prefix)
+sbindir = $(exec_prefix)/sbin
+libdir = $(exec_prefix)/lib
+# Should generally be /usr/local/etc but systemd only reads from /etc
+sysconfdir=/etc
+
 wondershaper:
 	exit;
   
 install:
-	install -Dm755 wondershaper /usr/sbin/wondershaper;
-	install -Dm644 wondershaper.service /etc/systemd/system/wondershaper.service;
-	install -Dm644 wondershaper.conf /etc/systemd/wondershaper.conf;
+	install -Dm755 wondershaper $(sbindir)/wondershaper;
+	install -Dm644 wondershaper.service $(libdir)/systemd/system/wondershaper.service;
+	install -Dm644 wondershaper.conf $(sysconfdir)/systemd/wondershaper.conf;
 
 uninstall:
-	rm -f /usr/sbin/wondershaper;
-	rm -f /usr/lib/systemd/system/wondershaper.service;
-	rm -f /etc/conf.d/wondershaper.conf;
+	rm -f $(sbindir)/wondershaper;
+	rm -f $(libdir)/systemd/system/wondershaper.service;
+	rm -f $(sysconfdir)/systemd/wondershaper.conf;
 
 clean:
 	rm  wondershaper;


### PR DESCRIPTION
The Makefile is written in a pretty unorthodox way which might make the
user surprised.

Use GNU defaults (https://www.gnu.org/software/make/manual/make.html).

- Default to prefix=/usr/local instead of /usr
- Make these variables overridable