### PR TITLE
Fix wondershaper.conf

### DIFF
--- a/wondershaper.conf
+++ b/wondershaper.conf
@@ -1,5 +1,3 @@
-[wondershaper]
-
 # Adapter
 IFACE="eth0"
 


### PR DESCRIPTION
The conf file is `source`d into the `wondershaper` bash script, so it must be a conforming bash code. Section names in square brackets are not valid bash syntax.