### PR TITLE
This PR enables modification of a previously specified configuration

### DIFF
--- a/wondershaper
+++ b/wondershaper
@@ -140,34 +140,53 @@ if [[ -z "$DSPEED" ]] && [[ -z "$USPEED" ]]; then
     exit 1;
 fi;
 
+function set_class_uplink() {
+    local mode=$1
+    if [[ -z "$mode" ]]; then
+        mode=add
+    fi
+
+    tc class $mode dev "$IFACE" parent 1: classid 1:1 htb \
+        rate "${USPEED}kbit" \
+        prio 5 ${COMMONOPTIONS[@]};
+
+    RATE=$((20*${USPEED}/100))
+    if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
+    tc class $mode dev "$IFACE" parent 1:1 classid 1:10 htb \
+        rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
+        prio 1 ${COMMONOPTIONS[@]};
+
+    RATE=$((40*${USPEED}/100))
+    if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
+    tc class $mode dev "$IFACE" parent 1:1 classid 1:20 htb \
+        rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
+        prio 2 ${COMMONOPTIONS[@]};
+
+    RATE=$((20*${USPEED}/100))
+    if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
+    tc class $mode dev "$IFACE" parent 1:1 classid 1:30 htb \
+        rate "${RATE}kbit" ceil $((90*${USPEED}/100))kbit \
+        prio 3 ${COMMONOPTIONS[@]};
+}
+
+function set_class_downlink() {
+    local mode=$1
+    if [[ -z "$mode" ]]; then
+        mode=add
+    fi
+
+    tc class $mode dev "$IFB" parent 2: classid 2:1 htb \
+        rate "${DSPEED}kbit"
+}
+
 # Modify the current configuration
 if [ "$MODE" = "modify" ]; then
     if [[ -n "$USPEED" ]]; then
-        tc class change dev "$IFACE" parent 1: classid 1:1 htb \
-           rate "${USPEED}kbit" \
-           prio 5 ${COMMONOPTIONS[@]};
-
-        RATE=$((20*${USPEED}/100))
-        if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
-        tc class change dev "$IFACE" parent 1:1 classid 1:10 htb \
-           rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
-           prio 1 ${COMMONOPTIONS[@]};
-
-        RATE=$((40*${USPEED}/100))
-        if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
-        tc class change dev "$IFACE" parent 1:1 classid 1:20 htb \
-           rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
-           prio 2 ${COMMONOPTIONS[@]};
-
-        RATE=$((20*${USPEED}/100))
-        if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
-        tc class change dev "$IFACE" parent 1:1 classid 1:30 htb \
-           rate "${RATE}kbit" ceil $((90*${USPEED}/100))kbit \
-           prio 3 ${COMMONOPTIONS[@]};
+        set_class_uplink change
     fi
 
     if [[ -n "$DSPEED" ]]; then
-        tc class change dev "$IFB" parent 2: classid 2:1 htb rate "${DSPEED}kbit"
+        set_class_downlink change
     fi
 
     exit
@@ -183,34 +202,8 @@ tc qdisc add dev "$IFACE" root handle 1: htb default 20;
 # DSL modem which destroy latency:
 # main class
 if [[ -n "$USPEED" ]]; then
-  tc class add dev "$IFACE" parent 1: classid 1:1 htb \
-    rate "${USPEED}kbit" \
-    prio 5 ${COMMONOPTIONS[@]};
 
-  # high prio class 1:10:
-
-  RATE=$((20*${USPEED}/100))
-  if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
-  tc class add dev "$IFACE" parent 1:1 classid 1:10 htb \
-    rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
-    prio 1 ${COMMONOPTIONS[@]};
-
-  # bulk and default class 1:20 - gets slightly less traffic,
-  #  and a lower priority:
-
-  RATE=$((40*${USPEED}/100))
-  if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
-  tc class add dev "$IFACE" parent 1:1 classid 1:20 htb \
-    rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
-    prio 2 ${COMMONOPTIONS[@]};
-
-  # 'traffic we hate'
-
-  RATE=$((20*${USPEED}/100))
-  if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
-  tc class add dev "$IFACE" parent 1:1 classid 1:30 htb \
-    rate "${RATE}kbit" ceil $((90*${USPEED}/100))kbit \
-    prio 3 ${COMMONOPTIONS[@]};
+  set_class_uplink
 
   # all get Stochastic Fairness:
   tc qdisc add dev "$IFACE" parent 1:10 handle 10: sfq perturb 10 quantum "$QUANTUM";
@@ -292,7 +285,7 @@ if [[ -n "$DSPEED" ]]; then
 
   # Add class and rules for virtual
   tc qdisc add dev "$IFB" root handle 2: htb;
-  tc class add dev "$IFB" parent 2: classid 2:1 htb rate "${DSPEED}kbit";
+  set_class_downlink
 
   # Add filter to rule for IP address
   tc filter add dev "$IFB" protocol ip parent 2: prio 1 u32 \

--- a/wondershaper
+++ b/wondershaper
@@ -140,7 +140,7 @@ if [[ -z "$DSPEED" ]] && [[ -z "$USPEED" ]]; then
     exit 1;
 fi;
 
-# Update the current configuration
+# Modify the current configuration
 if [ "$MODE" = "modify" ]; then
     if [[ -n "$USPEED" ]]; then
         tc class change dev "$IFACE" parent 1: classid 1:1 htb \

--- a/wondershaper
+++ b/wondershaper
@@ -53,6 +53,7 @@ OPTIONS:
    -f <file>    Use alternative preset file
    -c           Clear the limits from adapter
    -s           Show the current status of adapter
+   -m           Modify the current configuration
    -v           Show the current version
 
    Configure HIPRIODST in "$CONF" for hosts
@@ -79,7 +80,7 @@ IFB="ifb0";
 LOAD_PRESETS=false
 MODE=""
 
-while getopts hvf:d:u:a:pcs o; do
+while getopts hvf:d:u:a:pcsm o; do
   case "$o" in
     h)	usage;
       exit 1;;
@@ -92,6 +93,7 @@ while getopts hvf:d:u:a:pcs o; do
     p) LOAD_PRESETS=true;;
     c) MODE="clear";;
     s) MODE="status";;
+    m) MODE="modify";;
     [?])	usage;
 		exit 1;;
 	esac;
@@ -137,6 +139,39 @@ if [[ -z "$DSPEED" ]] && [[ -z "$USPEED" ]]; then
     usage;
     exit 1;
 fi;
+
+# Update the current configuration
+if [ "$MODE" = "modify" ]; then
+    if [[ -n "$USPEED" ]]; then
+        tc class change dev "$IFACE" parent 1: classid 1:1 htb \
+           rate "${USPEED}kbit" \
+           prio 5 ${COMMONOPTIONS[@]};
+
+        RATE=$((20*${USPEED}/100))
+        if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
+        tc class change dev "$IFACE" parent 1:1 classid 1:10 htb \
+           rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
+           prio 1 ${COMMONOPTIONS[@]};
+
+        RATE=$((40*${USPEED}/100))
+        if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
+        tc class change dev "$IFACE" parent 1:1 classid 1:20 htb \
+           rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
+           prio 2 ${COMMONOPTIONS[@]};
+
+        RATE=$((20*${USPEED}/100))
+        if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
+        tc class change dev "$IFACE" parent 1:1 classid 1:30 htb \
+           rate "${RATE}kbit" ceil $((90*${USPEED}/100))kbit \
+           prio 3 ${COMMONOPTIONS[@]};
+    fi
+
+    if [[ -n "$DSPEED" ]]; then
+        tc class change dev "$IFB" parent 2: classid 2:1 htb rate "${DSPEED}kbit"
+    fi
+
+    exit
+fi
 
 ###### uplink
 

--- a/wondershaper
+++ b/wondershaper
@@ -146,8 +146,7 @@ fi;
 ###### uplink
 
 # install root HTB
-
-tc qdisc add dev "$IFACE" root handle 1: htb default 20;
+tc qdisc add $TCMODE "$IFACE" root handle 1: htb default 20;
 
 # shape everything at $USPEED speed - this prevents huge queues in your
 # DSL modem which destroy latency:

--- a/wondershaper
+++ b/wondershaper
@@ -148,7 +148,7 @@ fi;
 # install root HTB
 
 if [ "$TCMODE" = "add" ]; then
-  tc qdisc add $TCMODE "$IFACE" root handle 1: htb default 20;
+  tc qdisc add dev "$IFACE" root handle 1: htb default 20;
 fi;
 
 # shape everything at $USPEED speed - this prevents huge queues in your

--- a/wondershaper
+++ b/wondershaper
@@ -146,8 +146,9 @@ fi;
 ###### uplink
 
 # install root HTB
-
-tc qdisc add dev "$IFACE" root handle 1: htb default 20;
+if [ "$TCMODE" = "add" ]k then
+  tc qdisc $TCMODE dev "$IFACE" root handle 1: htb default 20;
+fi;
 
 # shape everything at $USPEED speed - this prevents huge queues in your
 # DSL modem which destroy latency:

--- a/wondershaper
+++ b/wondershaper
@@ -186,7 +186,7 @@ if [[ -n "$USPEED" ]]; then
 
 fi;
 
-if [[ -n "$DSPEED" ]] && [ "$TCMODE" = "add" ]; then
+if [[ -n "$USPEED" ]] && [ "$TCMODE" = "add" ]; then
 
   # all get Stochastic Fairness:
   tc qdisc add dev "$IFACE" parent 1:10 handle 10: sfq perturb 10 quantum "$QUANTUM";

--- a/wondershaper
+++ b/wondershaper
@@ -61,12 +61,14 @@ OPTIONS:
 
 MODES:
    wondershaper -a <adapter> -d <rate> -u <rate>
+   wondershaper -m -a <adapter> -d <rate> -u <rate>
    wondershaper -c -a <adapter>
    wondershaper -s -a <adapter>
 
 EXAMPLES:
    wondershaper -a eth0 -d 1024 -u 512
    wondershaper -a eth0 -u 512
+   wondershaper -m -a eth0 -u 256
    wondershaper -c -a eth0
    wondershaper -p -f foo.conf
 
@@ -79,6 +81,7 @@ IFACE="";
 IFB="ifb0";
 LOAD_PRESETS=false
 MODE=""
+TCMODE="add"
 
 while getopts hvf:d:u:a:pcsm o; do
   case "$o" in
@@ -93,7 +96,7 @@ while getopts hvf:d:u:a:pcsm o; do
     p) LOAD_PRESETS=true;;
     c) MODE="clear";;
     s) MODE="status";;
-    m) MODE="modify";;
+    m) TCMODE="change";;
     [?])	usage;
 		exit 1;;
 	esac;
@@ -140,58 +143,6 @@ if [[ -z "$DSPEED" ]] && [[ -z "$USPEED" ]]; then
     exit 1;
 fi;
 
-function set_class_uplink() {
-    local mode=$1
-    if [[ -z "$mode" ]]; then
-        mode=add
-    fi
-
-    tc class $mode dev "$IFACE" parent 1: classid 1:1 htb \
-        rate "${USPEED}kbit" \
-        prio 5 ${COMMONOPTIONS[@]};
-
-    RATE=$((20*${USPEED}/100))
-    if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
-    tc class $mode dev "$IFACE" parent 1:1 classid 1:10 htb \
-        rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
-        prio 1 ${COMMONOPTIONS[@]};
-
-    RATE=$((40*${USPEED}/100))
-    if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
-    tc class $mode dev "$IFACE" parent 1:1 classid 1:20 htb \
-        rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
-        prio 2 ${COMMONOPTIONS[@]};
-
-    RATE=$((20*${USPEED}/100))
-    if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
-    tc class $mode dev "$IFACE" parent 1:1 classid 1:30 htb \
-        rate "${RATE}kbit" ceil $((90*${USPEED}/100))kbit \
-        prio 3 ${COMMONOPTIONS[@]};
-}
-
-function set_class_downlink() {
-    local mode=$1
-    if [[ -z "$mode" ]]; then
-        mode=add
-    fi
-
-    tc class $mode dev "$IFB" parent 2: classid 2:1 htb \
-        rate "${DSPEED}kbit"
-}
-
-# Modify the current configuration
-if [ "$MODE" = "modify" ]; then
-    if [[ -n "$USPEED" ]]; then
-        set_class_uplink change
-    fi
-
-    if [[ -n "$DSPEED" ]]; then
-        set_class_downlink change
-    fi
-
-    exit
-fi
-
 ###### uplink
 
 # install root HTB
@@ -202,8 +153,36 @@ tc qdisc add dev "$IFACE" root handle 1: htb default 20;
 # DSL modem which destroy latency:
 # main class
 if [[ -n "$USPEED" ]]; then
+  tc class $TCMODE dev "$IFACE" parent 1: classid 1:1 htb \
+    rate "${USPEED}kbit" \
+    prio 5 ${COMMONOPTIONS[@]};
 
-  set_class_uplink
+  # high prio class 1:10:
+
+  RATE=$((20*${USPEED}/100))
+  if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
+  tc class $TCMODE dev "$IFACE" parent 1:1 classid 1:10 htb \
+    rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
+    prio 1 ${COMMONOPTIONS[@]};
+
+  # bulk and default class 1:20 - gets slightly less traffic,
+  #  and a lower priority:
+
+  RATE=$((40*${USPEED}/100))
+  if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
+  tc class $TCMODE dev "$IFACE" parent 1:1 classid 1:20 htb \
+    rate "${RATE}kbit" ceil $((95*${USPEED}/100))kbit \
+    prio 2 ${COMMONOPTIONS[@]};
+
+  # 'traffic we hate'
+
+  RATE=$((20*${USPEED}/100))
+  if [ "$RATE" -eq 0 ]; then RATE=1 ; fi
+  tc class $TCMODE dev "$IFACE" parent 1:1 classid 1:30 htb \
+    rate "${RATE}kbit" ceil $((90*${USPEED}/100))kbit \
+    prio 3 ${COMMONOPTIONS[@]};
+
+ elif [[ -n "$DSPEED" ]] && [ "$TCMODE" = "add" ]; then
 
   # all get Stochastic Fairness:
   tc qdisc add dev "$IFACE" parent 1:10 handle 10: sfq perturb 10 quantum "$QUANTUM";
@@ -273,7 +252,7 @@ fi;
 # ISPs tend to have *huge* queues to make sure big downloads are fast
 #
 # attach ingress policer:
-if [[ -n "$DSPEED" ]]; then
+if [[ -n "$DSPEED" ]] && [ "$TCMODE" = "add" ]; then
   # Add the IFB interface
   modprobe ifb numifbs=1;
   ip link set dev "$IFB" up;
@@ -285,13 +264,16 @@ if [[ -n "$DSPEED" ]]; then
 
   # Add class and rules for virtual
   tc qdisc add dev "$IFB" root handle 2: htb;
-  set_class_downlink
 
   # Add filter to rule for IP address
   tc filter add dev "$IFB" protocol ip parent 2: prio 1 u32 \
     match ip src 0.0.0.0/0 flowid 2:1;
 
+elif [[ -n "$DSPEED" ]]; then
+  tc class $TCMODE dev "$IFB" parent 2: classid 2:1 htb rate "${DSPEED}kbit";
+
 fi;
+
 
 ### EOF
 ### vim:tw=80:et:sts=2:st=2:sw=2:com+=b\:###:fo+=cqtrw:tags=tags:

--- a/wondershaper
+++ b/wondershaper
@@ -147,7 +147,9 @@ fi;
 
 # install root HTB
 
-tc qdisc add $TCMODE "$IFACE" root handle 1: htb default 20;
+if [ "$TCMODE" = "add" ]; then
+  tc qdisc add $TCMODE "$IFACE" root handle 1: htb default 20;
+fi;
 
 # shape everything at $USPEED speed - this prevents huge queues in your
 # DSL modem which destroy latency:

--- a/wondershaper
+++ b/wondershaper
@@ -182,7 +182,9 @@ if [[ -n "$USPEED" ]]; then
     rate "${RATE}kbit" ceil $((90*${USPEED}/100))kbit \
     prio 3 ${COMMONOPTIONS[@]};
 
- elif [[ -n "$DSPEED" ]] && [ "$TCMODE" = "add" ]; then
+fi;
+
+if [[ -n "$DSPEED" ]] && [ "$TCMODE" = "add" ]; then
 
   # all get Stochastic Fairness:
   tc qdisc add dev "$IFACE" parent 1:10 handle 10: sfq perturb 10 quantum "$QUANTUM";
@@ -269,7 +271,9 @@ if [[ -n "$DSPEED" ]] && [ "$TCMODE" = "add" ]; then
   tc filter add dev "$IFB" protocol ip parent 2: prio 1 u32 \
     match ip src 0.0.0.0/0 flowid 2:1;
 
-elif [[ -n "$DSPEED" ]]; then
+fi;
+
+if [[ -n "$DSPEED" ]]; then
   tc class $TCMODE dev "$IFB" parent 2: classid 2:1 htb rate "${DSPEED}kbit";
 
 fi;


### PR DESCRIPTION
In some cases we don't want to clear and then set the neccesary upload and download rates. For example, clearing and installation of new limits allow maximum throughput for a small period of time violating desired limits. Instead, modification of the current limits is needed. This PR enables this capability.